### PR TITLE
Update link to 'Regular Expressions Cheat Sheet'

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Sharing, suggestions and contributions are always welcome! Please take a look at
 
 ## Cheat Sheets
 
-- [Regular Expressions Cheat Sheet](http://www.addedbytes.com/cheat-sheets/regular-expressions-cheat-sheet/)
+- [Regular Expressions Cheat Sheet](https://www.cheatography.com/davechild/cheat-sheets/regular-expressions/)
 - [Regex Cheat Sheet](http://www.rexegg.com/regex-quickstart.html)
 - [MIT Cheat Sheet](http://web.mit.edu/hackl/www/lab/turkshop/slides/regex-cheatsheet.pdf)
 - [Java Cheat Sheet](https://zeroturnaround.com/rebellabs/java-regular-expressions-cheat-sheet/)


### PR DESCRIPTION
Previous link was going to "Page not found". Looks like the cheat sheet moved to https://www.cheatography.com/davechild/cheat-sheets/regular-expressions/